### PR TITLE
Update bootstrap-magnify.less

### DIFF
--- a/less/bootstrap-magnify.less
+++ b/less/bootstrap-magnify.less
@@ -13,6 +13,6 @@
     position: absolute;
     display: none;
     width: 175px; height: 175px;
-    .box-shadow(0 0 0 7px rgba(255, 255, 255, 0.85), 0 0 7px 7px rgba(0, 0, 0, 0.25), inset 0 0 40px 2px rgba(0, 0, 0, 0.25));
-    .border-radius(100%);
+    .box-shadow(e('0 0 0 7px rgba(255, 255, 255, 0.85), 0 0 7px 7px rgba(0, 0, 0, 0.25), inset 0 0 40px 2px rgba(0, 0, 0, 0.25)'));
+    border-radius: 50%;
 }


### PR DESCRIPTION
Changes in bootstrap 3.3
 - mixin border-radius removed
 - box-shadow accepts only one parametr
 - Chrome render bug with box-shadow, border-radius bigger then 50% and width is not dividable by 2 https://twitter.com/insekticid/status/562991315756277760